### PR TITLE
响应issue #28

### DIFF
--- a/src/el/utils.js
+++ b/src/el/utils.js
@@ -39,10 +39,20 @@ module.exports = {
     sleep: async (ms) => new Promise((res,) => setTimeout(res, ms)),
 
     sendMessage: async (ctx, group_id, message) => {
-        await ctx.send('send_group_msg', {
-            group_id,
-            message: message instanceof Array ? message.join('\n') : message
-        })
+        let idx = String(group_id).indexOf('-')
+        if (idx == -1) {
+            await ctx.send('send_group_msg', {
+                group_id,
+                message: message instanceof Array ? message.join('\n') : message
+            })
+        } else {
+            let guild_id = String(group_id).substring(0,idx)
+            let channel_id = String(group_id).substring(idx+1)            
+            await ctx.send('send_guild_channel_msg', {
+                guild_id, channel_id,
+                message: message instanceof Array ? message.join('\n') : message
+            })
+        }
     },
 
     sendMessagePrivate: async (ctx, user_id, message) => {


### PR DESCRIPTION
临时借用群消息方法实现发送消息到子频道
配置方式为将群号写成“频道号-子频道号”的格式
注意bot不会响应频道中的控制消息